### PR TITLE
Use dev03 geoserver

### DIFF
--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -36,7 +36,7 @@
        "'{\"rule_snow\": true, \"rule_hybrid\": true, \"rule_rain\": true}'"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/sandpiper/processes/wps_resolve_rules.py
+++ b/sandpiper/processes/wps_resolve_rules.py
@@ -50,7 +50,7 @@ class ResolveRules(Process):
                 abstract="Geoserver URL",
                 min_occurs=1,
                 max_occurs=1,
-                default="http://docker-dev01.pcic.uvic.ca:30123/geoserver/bc_regions/ows",
+                default="https://docker-dev03.pcic.uvic.ca/geoserver/bc_regions/ows",
                 data_type="string",
             ),
             LiteralInput(


### PR DESCRIPTION
Resolves #10.

## Changes
- New default url for `geoserver`

## Notes
This issue ended up being much simpler than I initially thought.  We did **not** have to create a whole new `geoserver` as `birdhouse-deploy` launches one off of their custom image. From there all I had to do was override the `geoserver`'s `data_dir` with the data we are using from storage.  The changes in repo are unsubstantial but I would still appreciate it if reviewers ran the demo to ensure things are working.