### PR TITLE
Docker rework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,31 @@
+# vim:set ft=dockerfile:
 FROM pcic/geospatial-python:gdal3
-
 MAINTAINER https://github.com/pacificclimate/sandpiper
 LABEL Description="sandpiper WPS" Vendor="pacificclimate" Version="0.1.0"
 
 ENV PIP_INDEX_URL="https://pypi.pacificclimate.org/simple/"
 ENV THREDDS_URL_ROOT="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets"
 
-WORKDIR /code
+# Update system
+RUN apk add \
+  libxml2-dev \
+  libxslt-dev \
+  linux-headers
 
-COPY requirements.txt ./
+COPY . /opt/wps
 
-RUN apk add libxml2-dev libxslt-dev linux-headers && \
-    pip3 install psutil && \
-    pip3 install sphinx && \
-    pip3 install -r requirements.txt --ignore-installed && \
-    pip3 install gunicorn
+WORKDIR /opt/wps
 
-COPY . .
+# Create python environment
+RUN ["python", "-m", "venv", "venv"]
 
+# Install WPS
+RUN ["sh", "-c", "source venv/bin/activate && pip install sphinx psutil && pip install -e ."]
+
+# Start WPS service on port 5003 on 0.0.0.0
 EXPOSE 5003
-
-CMD ["gunicorn", "--bind=0.0.0.0:5003", "sandpiper.wsgi:application"]
+ENTRYPOINT ["sh", "-c"]
+CMD ["source venv/bin/activate && exec sandpiper start -b 0.0.0.0"]
 
 # docker build -t pcic/sandpiper .
 # docker run -p 5003:5003 pcic/sandpiper

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SANITIZE_FILE := https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/raw/mas
 
 
 .PHONY: all
-all: apt develop test-all clean-test credentials test-notebooks-online
+all: apt develop test-all clean-test credentials test-notebooks-prod
 
 .PHONY: help
 help:
@@ -141,14 +141,19 @@ test-notebooks: notebook-sanitizer
 	@echo "Running notebook-based tests"
 	@bash -c "source $(VENV)/bin/activate && env LOCAL_URL=$(LOCAL_URL) pytest --nbval --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
 
-.PHONY: test-notebooks-online
-test-notebooks-online: notebook-sanitizer
-	@echo "Running notebook-based tests against online instance of sandpiper"
+.PHONY: test-notebooks-prod
+test-notebooks-prod: notebook-sanitizer
+	@echo "Running notebook-based tests against production instance of sandpiper"
 	@bash -c "source $(VENV)/bin/activate && pytest --nbval --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
+
+.PHONY: test-notebooks-dev
+test-notebooks-dev: notebook-sanitizer
+	@echo "Running notebook-based tests against development instance of sandpiper"
+	@bash -c "source $(VENV)/bin/activate && env DEV_URL=http://docker-dev03.pcic.uvic.ca:30101/wps pytest --nbval --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
 
 .PHONY: test-notebooks-custom
 test-notebooks-custom: notebook-sanitizer
-	@echo "Running notebook-based tests against custom docker instance of thunderbird"
+	@echo "Running notebook-based tests against custom instance of sandpiper"
 	@bash -c "source $(VENV)/bin/activate && env DEV_URL=http://docker-dev03.pcic.uvic.ca:$(DEV_PORT)/wps pytest --nbval --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
 
 

--- a/dev-component/wps.cfg
+++ b/dev-component/wps.cfg
@@ -1,0 +1,6 @@
+[server]
+outputurl = http://docker-dev03.pcic.uvic.ca:30101/outputs
+
+[logging]
+level = INFO
+db_echo = false

--- a/dev-component/wps.cfg
+++ b/dev-component/wps.cfg
@@ -2,5 +2,4 @@
 outputurl = http://docker-dev03.pcic.uvic.ca:30101/outputs
 
 [logging]
-level = INFO
-db_echo = false
+level = DEBUG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,14 @@ services:
   sandpiper-dev:
     image: pcic/sandpiper:i40-unable-to-collect-output
     container_name: sandpiper-dev
+    environment:
+      - PYWPS_CFG=/wps.cfg
     ports:
       - "30101:5003"
+    volumes:
+      - ./dev-component/wps.cfg:/wps.cfg
     restart: always
+
 networks:
   default:
     external:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   sandpiper-dev:
-    image: pcic/sandpiper:i40-unable-to-collect-output
+    image: pcic/sandpiper:latest
     container_name: sandpiper-dev
     environment:
       - PYWPS_CFG=/wps.cfg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,16 @@
-version: '3'
+version: '3.0'
 services:
-  wps:
-    build: .
-    image: pcic/sandpiper
+  sandpiper-dev:
+    image: pcic/sandpiper:i40-unable-to-collect-output
+    container_name: sandpiper-dev
     ports:
-      - "8101:5003"
+      - "30101:5003"
+    restart: always
+networks:
+  default:
+    external:
+      name: pcicbr0
+
 
 # docker-compose build
 # docker-compose up


### PR DESCRIPTION
This PR introduces a significant update to our `docker` related items.The plan is to provide these updates to all pcic birds. I have set up a development bird using `docker-compose`, run `make test-notebooks-dev` to run tests.

Resolves #40 
Resolves #37 

## `Dockerfile`
There has been a full rework of our `Dockerfile`. The rework was necessary to solve the output issues we were seeing across our birds. Furthermore, the rework brings the file closer in line with others in the `birdhouse-deploy` project. This ensures that we will not miss out on future `cruft` updates.

## `docker-compose.yml`
This file was updated for specific usage on `dev03`. It uses one of the available ports and the pcic network bridge. This allows the resulting container to have access to the `thredds` server. Meaning we can run full tests on this container without having to hook it into `birdhouse-deploy`. This greatly improves our development flexibility since we will no longer be stepping on each others toes. One note is that the `image` will have to be changed depending on your development branch.

## `dev-component`
Similar to `pavics-component` this houses any configuration files for the development container. Right now there is a single file with some override options.

## `Makefile`
The interaction between `make` and the notebooks has been updated. There are 4 separate commands: 
- `test-notebooks` - targets local instance of `sandpiper`
- `test-notebooks-prod` - targets production instance of `sandpiper`
- `test-notebooks-dev` - targets development instance of `sandpiper` as described by `docker-compose.yml`
- `test-notebooks-custom` - prompts user for port (use case being multiple people working on same bird)