### PR TITLE
Use asobj=True in notebooks

### DIFF
--- a/notebooks/wps_evaluate_rules_demo.ipynb
+++ b/notebooks/wps_evaluate_rules_demo.ipynb
@@ -91,8 +91,8 @@
        "\n",
        "Returns\n",
        "-------\n",
-       "truth_values : string\n",
-       "    Truth value of a parse tree for each rule\n",
+       "json : ComplexData:mimetype:`application/json`\n",
+       "    JSON file\n",
        "\u001b[0;31mFile:\u001b[0m      ~/code/birds/sandpiper/</tmp/sandpiper-venv/lib/python3.8/site-packages/birdy/client/base.py-2>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
@@ -128,9 +128,8 @@
     "    parse_tree=parse_tree,\n",
     "    variables=variables\n",
     ")\n",
-    "\n",
-    "truth_values = output.get()[0]\n",
-    "truth_values = eval(truth_values)"
+    "# Access the json contents as a dictionary by setting asobj=True\n",
+    "truth_values = output.get(asobj=True)[0]"
    ]
   },
   {
@@ -146,9 +145,7 @@
     "    parse_tree=parse_tree,\n",
     "    variables=variables\n",
     ")\n",
-    "\n",
-    "hybrid_truth_values = output.get()[0]\n",
-    "hybrid_truth_values = eval(hybrid_truth_values)"
+    "hybrid_truth_values = output.get(asobj=True)[0]"
    ]
   },
   {

--- a/notebooks/wps_parser_demo.ipynb
+++ b/notebooks/wps_parser_demo.ipynb
@@ -78,8 +78,8 @@
        "\n",
        "Returns\n",
        "-------\n",
-       "parsed_vars : string\n",
-       "    Dictionary containing the parse tree, variables, and region variable generated from each condition.\n",
+       "json : ComplexData:mimetype:`application/json`\n",
+       "    JSON file\n",
        "\u001b[0;31mFile:\u001b[0m      ~/code/birds/sandpiper/notebooks/</tmp/sandpiper-venv/lib/python3.8/site-packages/birdy/client/base.py-1>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
@@ -104,43 +104,17 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'(temp_djf_iamean_s0p_hist <= -6)': {'parse_tree': ('<=',\n",
-       "   'temp_djf_iamean_s0p_hist',\n",
-       "   -6.0),\n",
-       "  'variables': {'temp_djf_iamean_s0p_hist': {'variable': 'temp',\n",
-       "    'time_of_year': 'djf',\n",
-       "    'temporal': 'iamean',\n",
-       "    'spatial': 's0p',\n",
-       "    'percentile': 'hist'}},\n",
-       "  'region_variable': None},\n",
-       " '(temp_djf_iamean_s100p_hist >= 5)': {'parse_tree': ('>=',\n",
-       "   'temp_djf_iamean_s100p_hist',\n",
-       "   5.0),\n",
-       "  'variables': {'temp_djf_iamean_s100p_hist': {'variable': 'temp',\n",
-       "    'time_of_year': 'djf',\n",
-       "    'temporal': 'iamean',\n",
-       "    'spatial': 's100p',\n",
-       "    'percentile': 'hist'}},\n",
-       "  'region_variable': None}}"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "conditions = [\n",
     "    \"(temp_djf_iamean_s0p_hist <= -6)\",\n",
     "    \"(temp_djf_iamean_s100p_hist >= 5)\"\n",
     "]\n",
-    "output = sandpiper.parser(conditions=conditions)\n",
-    "parser_dict = eval(output.get()[0])\n",
-    "parser_dict"
+    "output = sandpiper.parser(\n",
+    "    conditions=conditions\n",
+    ")\n",
+    "# Access the json contents as a dictionary by setting asobj=True\n",
+    "parser_dict = output.get(asobj=True)[0]"
    ]
   },
   {

--- a/notebooks/wps_resolve_rules_demo.ipynb
+++ b/notebooks/wps_resolve_rules_demo.ipynb
@@ -23,7 +23,6 @@
     "from wps_tools.file_handling import csv_handler\n",
     "from wps_tools.testing import get_target_url\n",
     "from pkg_resources import resource_filename\n",
-    "from wps_tools.output_handling import json_to_dict, auto_construct_outputs\n",
     "\n",
     "# Ensure we are in the working directory with access to the data\n",
     "while os.path.basename(os.getcwd()) != \"sandpiper\":\n",
@@ -134,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,35 +156,13 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Access the output with json_to_dict() or auto_construct_outputs() from wps_tools.output_handling"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "# Pass one output json filepath to json_to_dict and return a dictionary\n",
-    "json_output = output.get()[0]\n",
-    "print(json_output)\n",
-    "json_to_dict(json_output)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"\"\"\"Pass a list of output file urls of any type to auto_construct_outputs\n",
-    "and return a list of automatically constructed python ojects based on\n",
-    "the file types \"\"\"\n",
-    "auto_construct_outputs(output.get())"
+    "# Access the json contents as a dictionary by setting asobj=True\n",
+    "rules = output.get(asobj=True)[0]"
    ]
   },
   {
@@ -197,18 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "rules = json.loads(requests.get(output.get()[0]).content.decode('utf-8'))\n",
-    "print(rules)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pywps>=4.2
 gdal==3.0.4
 jinja2
-click
+click==7.1.2
 psutil
 p2a_impacts==0.4.0
 wps-tools==1.2.0

--- a/sandpiper/io.py
+++ b/sandpiper/io.py
@@ -1,0 +1,5 @@
+from pywps import ComplexOutput, FORMATS
+
+json_output = ComplexOutput(
+    "json", "JSON Output", abstract="JSON file", supported_formats=[FORMATS.JSON],
+)

--- a/sandpiper/processes/wps_evaluate_rule.py
+++ b/sandpiper/processes/wps_evaluate_rule.py
@@ -1,13 +1,15 @@
+import os
+import json
 from pywps import Process, LiteralInput, LiteralOutput, ComplexInput, FORMATS
 from pywps.app.Common import Metadata
 from pywps.app.exceptions import ProcessError
 from functools import partial
-import json
 
 from p2a_impacts.fetch_data import get_dict_val
 from p2a_impacts.evaluator import evaluate_rule
 from wps_tools.logging import log_handler
 from wps_tools.io import log_level, collect_args
+from sandpiper.io import json_output
 from sandpiper.utils import logger
 
 
@@ -46,14 +48,7 @@ class EvaluateRule(Process):
             log_level,
         ]
 
-        outputs = [
-            LiteralOutput(
-                "truth_values",
-                "Truth Value Dictionary",
-                abstract="Truth value of a parse tree for each rule",
-                data_type="string",
-            ),
-        ]
+        outputs = [json_output]
 
         super(EvaluateRule, self).__init__(
             self._handler,
@@ -134,7 +129,11 @@ class EvaluateRule(Process):
             process_step="build_output",
         )
 
-        response.outputs["truth_values"].data = truth_values
+        filepath = os.path.join(self.workdir, "truth_values.json")
+        with open(filepath, "w") as f:
+            json.dump(truth_values, f)
+
+        response.outputs["json"].file = filepath
 
         log_handler(
             self,

--- a/sandpiper/processes/wps_parser.py
+++ b/sandpiper/processes/wps_parser.py
@@ -1,3 +1,5 @@
+import os
+import json
 from pywps import Process, LiteralInput, LiteralOutput
 from pywps.app.Common import Metadata
 from pywps.app.exceptions import ProcessError
@@ -5,6 +7,7 @@ from pywps.app.exceptions import ProcessError
 from p2a_impacts.parser import build_parse_tree
 from wps_tools.logging import log_handler
 from wps_tools.io import log_level
+from sandpiper.io import json_output
 from sandpiper.utils import logger
 
 
@@ -31,15 +34,7 @@ class Parser(Process):
             log_level,
         ]
 
-        outputs = [
-            LiteralOutput(
-                "parsed_vars",
-                "Parsed variables dictionary",
-                abstract="Dictionary containing the parse tree, variables, "
-                "and region variable generated from each condition.",
-                data_type="string",
-            ),
-        ]
+        outputs = [json_output]
 
         super(Parser, self).__init__(
             self._handler,
@@ -111,7 +106,11 @@ class Parser(Process):
             process_step="build_output",
         )
 
-        response.outputs["parsed_vars"].data = parsed_vars
+        filepath = os.path.join(self.workdir, "parsed_vars.json")
+        with open(filepath, "w") as f:
+            json.dump(parsed_vars, f)
+
+        response.outputs["json"].file = filepath
 
         log_handler(
             self,


### PR DESCRIPTION
Resolves #59 
- Use json output for `wps_parser` and `wps_evaluate_rule`
- Use `asobj=True` for reading all outputs

Test on port `30243`