### PR TITLE
I73 resolve dependencies

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pywps>=4.2
+pywps==4.4.5
 gdal==3.0.4
 jinja2
-click==7.1.2
+click>=8.0
 psutil
 p2a_impacts==0.4.0
 wps-tools==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ gdal==3.0.4
 jinja2
 click>=8.0
 psutil
+pyproj==3.0.0
 p2a_impacts==0.4.0
 wps-tools==2.0.0
 ce==3.2.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,8 @@ bumpversion
 twine
 cruft
 # Changing dependencies above this comment will create merge conflicts when updating the cookiecutter template with cruft. Add extra requirements below this line.
-black==19.10b0
+black==22.3.0
+nbclient~=0.5.10
 
 # notebook requirements
 jupyterlab

--- a/sandpiper/io.py
+++ b/sandpiper/io.py
@@ -1,5 +1,8 @@
 from pywps import ComplexOutput, FORMATS
 
 json_output = ComplexOutput(
-    "json", "JSON Output", abstract="JSON file", supported_formats=[FORMATS.JSON],
+    "json",
+    "JSON Output",
+    abstract="JSON file",
+    supported_formats=[FORMATS.JSON],
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, "README.md")).read()
 CHANGES = open(os.path.join(here, "CHANGES.md")).read()
-REQUIRES_PYTHON = ">=3.5.0"
+REQUIRES_PYTHON = ">=3.7.0"
 
 about = {}
 with open(os.path.join(here, "sandpiper", "__version__.py"), "r") as f:
@@ -28,9 +28,8 @@ classifiers = [
     "Programming Language :: Python",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,18 @@ setup(
     license="GNU General Public License v3",
     keywords="wps pywps birdhouse sandpiper",
     packages=find_packages(),
-    package_data={"sandpiper": ["tests/data/*.nc"], "tests": ["data/*.nc"],},
+    package_data={
+        "sandpiper": ["tests/data/*.nc"],
+        "tests": ["data/*.nc"],
+    },
     include_package_data=True,
     install_requires=reqs,
-    extras_require={"dev": dev_reqs,},  # pip install ".[dev]"
-    entry_points={"console_scripts": ["sandpiper=sandpiper.cli:cli",]},
+    extras_require={
+        "dev": dev_reqs,
+    },  # pip install ".[dev]"
+    entry_points={
+        "console_scripts": [
+            "sandpiper=sandpiper.cli:cli",
+        ]
+    },
 )

--- a/tests/test_wps_evaluate_rule.py
+++ b/tests/test_wps_evaluate_rule.py
@@ -16,7 +16,11 @@ def build_rule_input(rules):
 
 
 @pytest.mark.parametrize(
-    ("rules", "parse_tree", "variables",),
+    (
+        "rules",
+        "parse_tree",
+        "variables",
+    ),
     [
         (
             "rule_snow",
@@ -41,7 +45,16 @@ def test_wps_evaluate_rule(rules, parse_tree, variables):
 
 
 @pytest.mark.parametrize(
-    ("rules", "parse_tree",), [("rule_snow", local_path("parse_tree.json"),),],
+    (
+        "rules",
+        "parse_tree",
+    ),
+    [
+        (
+            "rule_snow",
+            local_path("parse_tree.json"),
+        ),
+    ],
 )
 def test_file_err(rules, parse_tree):
     with NamedTemporaryFile(
@@ -56,7 +69,11 @@ def test_file_err(rules, parse_tree):
 
 
 @pytest.mark.parametrize(
-    ("rules", "parse_tree", "variables",),
+    (
+        "rules",
+        "parse_tree",
+        "variables",
+    ),
     [
         (
             "rule_snow",

--- a/tests/test_wps_resolve_rules.py
+++ b/tests/test_wps_resolve_rules.py
@@ -7,7 +7,13 @@ from sandpiper.processes.wps_resolve_rules import ResolveRules
 
 @pytest.mark.online
 @pytest.mark.parametrize(
-    ("csv", "date_range", "region", "geoserver", "ensemble",),
+    (
+        "csv",
+        "date_range",
+        "region",
+        "geoserver",
+        "ensemble",
+    ),
     [
         (
             resource_filename("tests", "data/rules_small.csv"),
@@ -20,7 +26,13 @@ from sandpiper.processes.wps_resolve_rules import ResolveRules
 )
 @pytest.mark.parametrize("thredds", [True, False])
 def test_wps_resolve_rules(
-    mock_thredds_url_root, csv, date_range, region, geoserver, ensemble, thredds,
+    mock_thredds_url_root,
+    csv,
+    date_range,
+    region,
+    geoserver,
+    ensemble,
+    thredds,
 ):
     with open(csv, "r") as csv_file:
         datainputs = (


### PR DESCRIPTION
This PR resolves #73. In doing so, `pywps` has been pinned to 4.4.5 to fix an error with `test_wps_parser.py`, `pyproj` has been pinned to 3.0.0 to fix the docker image build, and `click`, `black`, and `nbclient` have had their versions changed to fix the incompatibilities. Additionally, support for Python 3.6 has been dropped.